### PR TITLE
Dev

### DIFF
--- a/sdcpy/__init__.py
+++ b/sdcpy/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Alejandro Fontal"""
 __email__ = 'alejandrofontal92@gmail.com'
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/AlFontal/sdcpy',
-    version='0.2.1',
+    version='0.2.2',
     zip_safe=False,
 )


### PR DESCRIPTION
Made some modifications in computation of critical ranges and the main `compute_sdc` function:

+ Fixed bug where xlab would always display absolute humidity information in plots.

+ Arg to choose whether to display text in bar plot for `plot_ranges`

+ Added thresholding: arg to limit the minimal amount of times values in a certain range appear to consider a comparison within such range

+ Reduce final dataframe to only include comparisons actually made when a range of lags is selected.

+ Warning suppression: Constant fragment errors in Spearman and Pearson R computation handled and suppressed.